### PR TITLE
chore: update workflows and dependencies

### DIFF
--- a/.github/workflows/build-and-push-jupyterlab-image.yml
+++ b/.github/workflows/build-and-push-jupyterlab-image.yml
@@ -11,27 +11,27 @@ jobs:
     steps:
     
       - name: Checkout
-        uses: actions/checkout@v3.5.0
+        uses: actions/checkout@v4
       
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2.5.0
+        uses: docker/setup-buildx-action@v3
             
-      - name: Login to dockerhub 
-        uses: docker/login-action@v2.1.0
+      - name: Login to dockerhub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Get lowercase repo name (for dynamic tags)
-        id: repo_name  
+        id: repo_name
         run: |
           lowercase_name=$(echo ${{ github.event.repository.name }} | tr '[:upper:]' '[:lower:]')
-          echo "::set-output name=repo_name::${lowercase_name}"
+          echo "repo_name=${lowercase_name}" >> "$GITHUB_OUTPUT"
         
       - name: Build and push latest
         id: docker_build_jupyterlab
-        uses: docker/build-push-action@v4.0.0
+        uses: docker/build-push-action@v5
         with:
           context: docker/jupyterlab
           file: docker/jupyterlab/Dockerfile
@@ -41,4 +41,4 @@ jobs:
             esiil/${{ steps.repo_name.outputs.repo_name }}_jupyterlab:latest
      
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo ${{ steps.docker_build_jupyterlab.outputs.digest }}

--- a/.github/workflows/fetch-template.yml
+++ b/.github/workflows/fetch-template.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - name: Checkout main repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Configure Git for merge
       run: |
@@ -29,6 +29,6 @@ jobs:
       run: git commit -am "Merge changes from template repository"
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@v0.6.0
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,10 +9,10 @@
      name: Deploy docs
      runs-on: ubuntu-latest
      steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4
+       - uses: actions/checkout@v4
+       - uses: actions/setup-python@v5
          with:
-           python-version: 3.9
+           python-version: '3.11'
        - name: run requirements file
          run:  pip install -r requirements.txt 
        - name: Deploy docs

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ mkdocstrings-python-legacy
 # Requirements for core
 jinja2>=3.0
 markdown>=3.2
-mkdocs==1.5.3
+mkdocs>=1.6.0
 mkdocs-material-extensions>=1.1
 pygments>=2.14
 pymdown-extensions>=9.9.1


### PR DESCRIPTION
## Summary
- modernize Docker image build workflow with latest checkout and Docker actions and drop deprecated set-output usage
- sync template workflow with current checkout and push actions
- use Python 3.11 and newer GitHub Actions when publishing docs, and require MkDocs 1.6+

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mkdocs>=1.6.0)*
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c1d98234a88325bd93b18463f1600b